### PR TITLE
Re-enable and improve main-branch workflow

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry (GHCR)
         uses: docker/login-action@v3
         with:
@@ -135,38 +138,33 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Build and Tag Docker Images
-        run: |
-          IMAGE_TAG=${{ steps.get_version.outputs.version || 'latest' }}
-          
-          # Build backend image
-          docker build -t backend:$IMAGE_TAG -t backend:latest ./backend
-          docker tag backend:$IMAGE_TAG \
-            ghcr.io/datascientest-fastapi-project-group-25/backend:$IMAGE_TAG
-          docker tag backend:latest \
+      
+      # Backend image build and push
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: |
+            ghcr.io/datascientest-fastapi-project-group-25/backend:${{ steps.get_version.outputs.version || 'latest' }}
             ghcr.io/datascientest-fastapi-project-group-25/backend:latest
-          
-          # Build frontend image
-          docker build -t frontend:$IMAGE_TAG -t frontend:latest ./frontend \
-            --build-arg VITE_API_URL=http://localhost:8000 \
-            --build-arg NODE_ENV=production
-          docker tag frontend:$IMAGE_TAG \
-            ghcr.io/datascientest-fastapi-project-group-25/frontend:$IMAGE_TAG
-          docker tag frontend:latest \
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      
+      # Frontend image build and push
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: |
+            ghcr.io/datascientest-fastapi-project-group-25/frontend:${{ steps.get_version.outputs.version || 'latest' }}
             ghcr.io/datascientest-fastapi-project-group-25/frontend:latest
-
-      - name: Push Docker Images to GHCR
-        run: |
-          IMAGE_TAG=${{ steps.get_version.outputs.version || 'latest' }}
-          
-          # Push backend images
-          docker push ghcr.io/datascientest-fastapi-project-group-25/backend:$IMAGE_TAG
-          docker push ghcr.io/datascientest-fastapi-project-group-25/backend:latest
-          
-          # Push frontend images
-          docker push ghcr.io/datascientest-fastapi-project-group-25/frontend:$IMAGE_TAG
-          docker push ghcr.io/datascientest-fastapi-project-group-25/frontend:latest
+          build-args: |
+            VITE_API_URL=http://localhost:8000
+            NODE_ENV=production
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Notify image publication
         run: |


### PR DESCRIPTION
This PR re-enables the main-branch workflow with several important improvements:

## Changes
- Added `--system` flag to `uv pip install` commands to avoid virtual environment issues
- Improved Docker build process to use separate contexts for backend and frontend
- Added proper permissions for GitHub Container Registry access
- Simplified conditional logic by using job outputs instead of repeating conditions
- Renamed deployment job to 'publish-images' to better reflect its purpose
- Updated notification messages to clarify the separation between image publishing and deployment
- Removed direct push triggers to align with branch protection strategy

## Testing
- The workflow has been updated to follow best practices
- All changes maintain compatibility with existing CI/CD pipeline
- Workflow will only run on PR merges to main, not direct pushes

## Related
- Part of the systematic re-enablement of GitHub Actions workflows