### PR TITLE
Fix: Add email configuration variables to workflow for tests

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -96,6 +96,14 @@ jobs:
           FIRST_SUPERUSER: "admin@example.com"
           FIRST_SUPERUSER_PASSWORD: "adminpass123"
           
+          # Email configuration for testing
+          EMAILS_ENABLED: "True"
+          SMTP_HOST: "localhost"
+          SMTP_PORT: "25"
+          SMTP_USER: "test@example.com"
+          SMTP_PASSWORD: "testpassword"
+          EMAILS_FROM_EMAIL: "test@example.com"
+          
           # Security
           SECRET_KEY: "testing_secret_key_for_ci"
         run: |
@@ -125,6 +133,14 @@ jobs:
           # User configuration
           FIRST_SUPERUSER: "admin@example.com"
           FIRST_SUPERUSER_PASSWORD: "adminpass123"
+          
+          # Email configuration for testing
+          EMAILS_ENABLED: "True"
+          SMTP_HOST: "localhost"
+          SMTP_PORT: "25"
+          SMTP_USER: "test@example.com"
+          SMTP_PASSWORD: "testpassword"
+          EMAILS_FROM_EMAIL: "test@example.com"
           
           # Security
           SECRET_KEY: "testing_secret_key_for_ci"


### PR DESCRIPTION
This PR adds the necessary email configuration variables to the main-branch.yml workflow file to fix the failing tests in the CI/CD pipeline.\n\nChanges:\n- Added email configuration variables (EMAILS_ENABLED, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, EMAILS_FROM_EMAIL) to both the database initialization step and backend tests step\n- This ensures that the password recovery test can run successfully without failing due to missing email configuration\n\nThis fix addresses the 'No provided configuration for email variables' error that was occurring in the test_recovery_password test.