### PR TITLE
Fix: Install linting tools before running linting checks

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -156,6 +156,8 @@ jobs:
       - name: Run linting
         run: |
           cd backend
+          # Install linting tools first
+          uv pip install --system flake8 black
           flake8 app
           black --check app
 


### PR DESCRIPTION
This PR updates the main-branch.yml workflow to install the necessary linting tools (flake8 and black) before running the linting checks.\n\nChanges:\n- Added commands to install flake8 and black using uv pip before running the linting checks\n- This fixes the workflow failure where the linting step was failing with 'command not found' errors\n\nThis is the third fix in our series of improvements to the database initialization workflow:\n1. First we updated the test user password to meet validation requirements\n2. Then we added email configuration variables for the tests\n3. Now we're fixing the linting step by installing the required tools