### PR TITLE
Fix: Sort imports in security.py to fix ruff linting error

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,6 +1,6 @@
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
-import logging
 
 import jwt
 from passlib.context import CryptContext


### PR DESCRIPTION
This PR fixes the import order in security.py to resolve the ruff linting error that was causing the CI workflow to fail.