### PR TITLE
Fix: Add handleError export and install Playwright browsers in CI

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -205,6 +205,11 @@ jobs:
           cd backend
           pytest -xvs app/tests/
 
+      - name: Install Playwright browsers
+        run: |
+          cd frontend
+          pnpm exec playwright install --with-deps
+
       - name: Run frontend tests
         run: |
           cd frontend

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -55,6 +55,14 @@ export const formatApiError = (err: ApiError): string => {
   return errorMessage;
 };
 
+// This is a placeholder for components that import handleError directly
+// They should be updated to use useApiErrorHandler hook instead
+export const handleError = (err: ApiError) => {
+  console.error("API Error:", formatApiError(err));
+  // Note: This is a temporary solution. Components should use useApiErrorHandler hook
+  // which provides proper toast notifications
+};
+
 export const useApiErrorHandler = () => {
   const { showErrorToast } = useCustomToast();
 


### PR DESCRIPTION
This PR adds a handleError export to utils.ts and installs Playwright browsers in the CI workflow to fix the failing tests.