### PR TITLE
Fix test-fixed target to use system Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,13 +351,7 @@ test-frontend: ## Run frontend tests (JavaScript/TypeScript with Vitest)
 
 test-fixed: ## Run tests with fixed port configuration
 	@echo "🧪 Running tests with fixed port configuration..."
-	@if [ -d "backend/.venv" ]; then \
-		echo "Using virtual environment..."; \
-		cd backend && . .venv/bin/activate && python -m pytest tests/unit tests/integration tests/api tests/crud -v; \
-	else \
-		echo "No virtual environment found. Using system Python..."; \
-		cd backend && python -m pytest tests/unit tests/integration tests/api tests/crud -v; \
-	fi
+	@cd backend && python -m pytest tests/unit tests/integration tests/api tests/crud -v
 	@echo "✅ Backend tests complete!"
 	@cd frontend && pnpm run test:unit
 	@echo "✅ Frontend unit tests complete!"


### PR DESCRIPTION
This PR simplifies the test-fixed target in the Makefile to use the system Python instead of trying to use a virtual environment.

This makes the test-fixed target more robust and ensures it works in different environments.