### PR TITLE
Fix test-fixed target to use python3 instead of python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ test-frontend: ## Run frontend tests (JavaScript/TypeScript with Vitest)
 
 test-fixed: ## Run tests with fixed port configuration
 	@echo "🧪 Running tests with fixed port configuration..."
-	@cd backend && python -m pytest tests/unit tests/integration tests/api tests/crud -v
+	@cd backend && python3 -m pytest tests/unit tests/integration tests/api tests/crud -v
 	@echo "✅ Backend tests complete!"
 	@cd frontend && pnpm run test:unit
 	@echo "✅ Frontend unit tests complete!"


### PR DESCRIPTION
This PR updates the test-fixed target in the Makefile to use python3 instead of python.

This makes the test-fixed target more robust and ensures it works in different environments.