### PR TITLE
fix: use lowercase repository names in Docker image tags

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -68,24 +68,24 @@ jobs:
       - name: Pull staging images
         run: |
           # Pull the staging images
-          docker pull ghcr.io/${{ github.repository }}-backend:stg
-          docker pull ghcr.io/${{ github.repository }}-frontend:stg
+          docker pull ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:stg
+          docker pull ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:stg
 
       - name: Retag and push production images
         run: |
           # Retag with semantic version and latest
-          docker tag ghcr.io/${{ github.repository }}-backend:stg ghcr.io/${{ github.repository }}-backend:${{ env.NEW_VERSION }}
-          docker tag ghcr.io/${{ github.repository }}-backend:stg ghcr.io/${{ github.repository }}-backend:latest
+          docker tag ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:stg ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:${{ env.NEW_VERSION }}
+          docker tag ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:stg ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:latest
 
-          docker tag ghcr.io/${{ github.repository }}-frontend:stg ghcr.io/${{ github.repository }}-frontend:${{ env.NEW_VERSION }}
-          docker tag ghcr.io/${{ github.repository }}-frontend:stg ghcr.io/${{ github.repository }}-frontend:latest
+          docker tag ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:stg ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:${{ env.NEW_VERSION }}
+          docker tag ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:stg ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:latest
 
           # Push the new tags
-          docker push ghcr.io/${{ github.repository }}-backend:${{ env.NEW_VERSION }}
-          docker push ghcr.io/${{ github.repository }}-backend:latest
+          docker push ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:${{ env.NEW_VERSION }}
+          docker push ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:latest
 
-          docker push ghcr.io/${{ github.repository }}-frontend:${{ env.NEW_VERSION }}
-          docker push ghcr.io/${{ github.repository }}-frontend:latest
+          docker push ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:${{ env.NEW_VERSION }}
+          docker push ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:latest
 
       - name: Update VERSION file
         run: |

--- a/.github/workflows/merge-to-staging.yml
+++ b/.github/workflows/merge-to-staging.yml
@@ -56,8 +56,8 @@ jobs:
           file: ./backend/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-backend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}
-            ghcr.io/${{ github.repository }}-backend:stg
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:stg
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
           build-args: |
@@ -71,8 +71,8 @@ jobs:
           file: ./frontend/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-frontend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}
-            ghcr.io/${{ github.repository }}-frontend:stg
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:stg
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
           build-args: |


### PR DESCRIPTION
This PR fixes the Docker image tag names to use lowercase repository names, which is required by Docker.