### PR TITLE
fix: use lowercase repository names in Docker image tags for build-stg-image.yml

### DIFF
--- a/.github/workflows/build-stg-image.yml
+++ b/.github/workflows/build-stg-image.yml
@@ -92,8 +92,8 @@ jobs:
           file: ./backend/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-backend:stg
-            ghcr.io/${{ github.repository }}-backend:${{ needs.bump-version.outputs.new_version }}
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:stg
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:${{ needs.bump-version.outputs.new_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -106,8 +106,8 @@ jobs:
           file: ./frontend/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-frontend:stg
-            ghcr.io/${{ github.repository }}-frontend:${{ needs.bump-version.outputs.new_version }}
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:stg
+            ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:${{ needs.bump-version.outputs.new_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -133,5 +133,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: sha,
-              body: `## 🚀 Staging Images Built and Pushed\n\n${bumpMessage}: **${version}**\n\nImages are available at:\n- \`ghcr.io/${context.repo.owner}/${context.repo.repo}-backend:stg\`\n- \`ghcr.io/${context.repo.owner}/${context.repo.repo}-backend:${version}\`\n- \`ghcr.io/${context.repo.owner}/${context.repo.repo}-frontend:stg\`\n- \`ghcr.io/${context.repo.owner}/${context.repo.repo}-frontend:${version}\``
+              body: `## 🚀 Staging Images Built and Pushed\n\n${bumpMessage}: **${version}**\n\nImages are available at:\n- \`ghcr.io/${context.repo.owner.toLowerCase()}/${context.repo.repo.toLowerCase()}-backend:stg\`\n- \`ghcr.io/${context.repo.owner.toLowerCase()}/${context.repo.repo.toLowerCase()}-backend:${version}\`\n- \`ghcr.io/${context.repo.owner.toLowerCase()}/${context.repo.repo.toLowerCase()}-frontend:stg\`\n- \`ghcr.io/${context.repo.owner.toLowerCase()}/${context.repo.repo.toLowerCase()}-frontend:${version}\``
             });


### PR DESCRIPTION
This PR fixes the Docker image tag names to use lowercase repository names in the build-stg-image.yml file, which is required by Docker.