### PR TITLE
fix: use lowercase repository names in PR body of merge-to-staging.yml

### DIFF
--- a/.github/workflows/merge-to-staging.yml
+++ b/.github/workflows/merge-to-staging.yml
@@ -99,8 +99,8 @@ jobs:
 
             ### Docker Images
 
-            - Backend: `ghcr.io/${{ github.repository }}-backend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}`
-            - Frontend: `ghcr.io/${{ github.repository }}-frontend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}`
+            - Backend: `ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-backend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}`
+            - Frontend: `ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}-frontend:${{ env.GIT_HASH }}-${{ env.BRANCH_TYPE }}`
           labels: |
             automated-pr
             release


### PR DESCRIPTION
This PR fixes the Docker image tag names in the PR body of merge-to-staging.yml to use lowercase repository names, which is required by Docker.