### PR TITLE
fix: use lowercase repository names in Docker image tags for all workflow files

### DIFF
--- a/.github/workflows/dev-branch-checks.yml
+++ b/.github/workflows/dev-branch-checks.yml
@@ -62,7 +62,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:staging-pr-${{ github.event.pull_request.number }}
+          tags: ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}:staging-pr-${{ github.event.pull_request.number }}
           target: staging
           cache-from: type=gha,scope=staging
           cache-to: type=gha,mode=max,scope=staging

--- a/.github/workflows/merge-to-stg.yml
+++ b/.github/workflows/merge-to-stg.yml
@@ -34,7 +34,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:staging
+          tags: ghcr.io/${{ github.repository_owner | lower }}/${{ github.event.repository.name | lower }}:staging
           target: staging
           cache-from: type=gha,scope=staging
           cache-to: type=gha,mode=max,scope=staging


### PR DESCRIPTION
This PR fixes the Docker image tag names in all workflow files to use lowercase repository names, which is required by Docker.