### PR TITLE
fix: set PNPM_HOME environment variable in Dockerfile to fix global bin directory issue

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,8 @@ FROM --platform=linux/amd64 node:18-alpine AS deps
 
 # Install pnpm and TypeScript globally
 RUN corepack enable && corepack prepare pnpm@8.11.0 --activate
+# Set up PNPM_HOME and add it to PATH
+ENV PNPM_HOME=/usr/local/bin
 RUN pnpm install -g typescript@latest
 
 # Set environment variables to avoid optional dependency issues
@@ -31,6 +33,8 @@ FROM --platform=linux/amd64 node:18-alpine AS builder
 
 # Install pnpm and TypeScript globally
 RUN corepack enable && corepack prepare pnpm@8.11.0 --activate
+# Set up PNPM_HOME and add it to PATH
+ENV PNPM_HOME=/usr/local/bin
 RUN pnpm install -g typescript@latest
 
 # Set environment variables
@@ -78,6 +82,8 @@ FROM --platform=linux/amd64 node:18-alpine AS development
 
 # Install pnpm and TypeScript globally
 RUN corepack enable && corepack prepare pnpm@8.11.0 --activate
+# Set up PNPM_HOME and add it to PATH
+ENV PNPM_HOME=/usr/local/bin
 RUN pnpm install -g typescript@latest
 
 # Set environment variables
@@ -107,7 +113,10 @@ WORKDIR /app
 COPY --from=builder /app/frontend/dist ./frontend/dist
 COPY --from=builder /app/frontend/package.json ./frontend/
 
-# Install only production dependencies
+# Install pnpm and serve
+RUN corepack enable && corepack prepare pnpm@8.11.0 --activate
+# Set up PNPM_HOME and add it to PATH
+ENV PNPM_HOME=/usr/local/bin
 RUN pnpm install -g serve
 
 # Expose port


### PR DESCRIPTION
This PR fixes the Docker build error for the frontend image.

## Issue
The Docker build was failing with the error:


## Fix
- Added PATH=/Users/jaronschulz/.bun/bin:/Users/jaronschulz/.local/state/fnm_multishells/42681_1744130105009/bin:/opt/homebrew/Caskroom/hashicorp-vagrant/2.4.2/bin:/Users/jaronschulz/.codeium/windsurf/bin:/usr/local/opt/imagemagick@6/bin:/opt/homebrew/bin/pnpm:/Users/jaronschulz/.npm-global/bin:/Users/jaronschulz/.local/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/jaronschulz/Library/Application Support/JetBrains/Toolbox/scripts:/Users/jaronschulz/go/bin:/Users/jaronschulz/Library/Android/sdk/tools:/Users/jaronschulz/Library/Android/sdk/platform-tools
FNM_RESOLVE_ENGINES=true
PKG_CONFIG_PATH=/opt/homebrew/opt/libffi/lib/pkgconfig /opt/homebrew/opt/zlib/lib/pkgconfig
OLLAMA_API_BASE=http://127.0.0.1:11434
FNM_COREPACK_ENABLED=false
MANPATH=/opt/homebrew/Cellar/antidote/1.9.7/share/antidote/man:
FNM_DIR=/Users/jaronschulz/Library/Application Support/fnm
STARSHIP_SESSION_KEY=1012632754769418
TERM=xterm-256color
HOMEBREW_PREFIX=/opt/homebrew
LDFLAGS=-L/opt/homebrew/opt/libffi/lib
COMMAND_MODE=unix2003
ANDROID_HOME=/Users/jaronschulz/Library/Android/sdk
AIDER_DARK_MODE=true
PNPM_HOME=/usr/local/bin
FNM_NODE_DIST_MIRROR=https://nodejs.org/dist
STARSHIP_CONFIG=/Users/jaronschulz/.config/starship.toml
STARSHIP_SHELL=zsh
LOGNAME=jaronschulz
HOMEBREW_REPOSITORY=/opt/homebrew
XPC_SERVICE_NAME=0
PWD=/Users/jaronschulz/Projects/Code/--Learning/dataScientest_devOps/+++Project/fastAPI-project-app
INFOPATH=/opt/homebrew/share/info:
__CFBundleIdentifier=com.jetbrains.pycharm
FNM_LOGLEVEL=info
SHELL=/opt/homebrew/bin/zsh
FNM_MULTISHELL_PATH=/Users/jaronschulz/.local/state/fnm_multishells/42681_1744130105009
CPPFLAGS=-I/opt/homebrew/opt/libffi/include
FNM_ARCH=arm64
LSCOLORS=ExGxBxDxCxEgEdxbxgxcxd
optflags=-Wno-error=implicit-function-declaration
SECURITYSESSIONID=186cb
OLDPWD=/Users/jaronschulz/Projects/Code/--Learning/dataScientest_devOps/+++Project/fastAPI-project-app
HOMEBREW_CELLAR=/opt/homebrew/Cellar
FNM_VERSION_FILE_STRATEGY=local
LM_STUDIO_API_KEY=dummy-api-key
USER=jaronschulz
CLICOLOR=1
BUN_INSTALL=/Users/jaronschulz/.bun
TMPDIR=/var/folders/72/zzylscwd6w5fs6lc4dkf1z700000gn/T/
LaunchInstanceID=8B1CEAA0-CC5D-4BC9-B3E1-50A2DC6B11C6
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.c0FT8Gq04Q/Listeners
LM_STUDIO_API_BASE=http://localhost:1234
XPC_FLAGS=0x0
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
OPENROUTER_API_KEY=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
LC_CTYPE=en_US.UTF-8
HOME=/Users/jaronschulz
SHLVL=1
_=/usr/bin/ENV to all stages in the Dockerfile
- This ensures PNPM can find the global bin directory for installing packages

## Testing
This fix should resolve the Docker build errors in the CI/CD pipeline for both staging and production environments.